### PR TITLE
Only rebuild on changes to (sass|scss|css) files

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,17 +14,13 @@ function SASSPlugin(optionsFn) {
 
 SASSPlugin.prototype.toTree = function(tree, inputPath, outputPath, inputOptions) {
   var options = Object.assign({}, this.optionsFn(), inputOptions);
-  var inputTrees;
 
-  if (options.onlyIncluded) {
-    inputTrees = [new Funnel(tree, {
-      include: ['app/styles/**/*'],
+  var inputTrees = [
+    new Funnel(tree, {
+      include: [options.onlyIncluded ? 'app/styles/**/*' : /\.(scss|sass|css)$/],
       annotation: 'Funnel (styles)'
-    })];
-  }
-  else {
-    inputTrees = [tree];
-  }
+    })
+  ];
 
   if (options.includePaths) {
     inputTrees = inputTrees.concat(options.includePaths);


### PR DESCRIPTION
Fixes #214. 

Related: 

- https://github.com/adopted-ember-addons/ember-cli-sass/pull/215 (seems to have other changes mixed in that aren't related to this specific issue)
- https://github.com/adopted-ember-addons/ember-cli-sass/pull/178 (relies on `extension` for filtering, doesn't account for the fact that SCSS files can import regular `.css` files too)